### PR TITLE
Replaced native folders paths with the new one on the new dart sdk

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 import 'package:flutter_launcher_icons/xml_templates.dart' as XmlTemplate;
 import 'package:image/image.dart';
 
-const String android_res_folder = "android/app/src/main/res/";
-const String android_colors_file = "android/app/src/main/res/values/colors.xml";
-const String android_manifest_file = "android/app/src/main/AndroidManifest.xml";
-const String android_gradle_file = "android/app/build.gradle";
+const String android_res_folder = ".android/app/src/main/res/";
+const String android_colors_file = ".android/app/src/main/res/values/colors.xml";
+const String android_manifest_file = ".android/app/src/main/AndroidManifest.xml";
+const String android_gradle_file = ".android/app/build.gradle";
 const String android_file_name = "ic_launcher.png";
 const String android_adaptive_foreground_file_name = "ic_launcher_foreground.png";
 const String android_adaptive_xml_folder =  android_res_folder + "mipmap-anydpi-v26/";

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -6,9 +6,9 @@ import 'dart:convert';
  * File to handle the creation of icons for iOS platform
  */
 const String default_icon_folder =
-    "ios/Runner/Assets.xcassets/AppIcon.appiconset/";
-const String asset_folder = "ios/Runner/Assets.xcassets/";
-const String config_file = "ios/Runner.xcodeproj/project.pbxproj";
+    ".ios/Runner/Assets.xcassets/AppIcon.appiconset/";
+const String asset_folder = ".ios/Runner/Assets.xcassets/";
+const String config_file = ".ios/Runner.xcodeproj/project.pbxproj";
 const String default_icon_name = "Icon-App";
 
 class IosIcon {


### PR DESCRIPTION
on the last version of dart sdk ( android / ios ) folders became ( .android / .ios ) with leading dot which caused to through error `FileSystemException: Cannot open file, path = 'android/app/build.gradle' (OS Error: No such file or directory, errno = 2)` ,, I replaced the paths with the new one and tested the command again it worked successfully.