### PR TITLE
Correct AppStore Icon Settings

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -261,8 +261,8 @@ List<Map> createImageList(String fileNamePrefix) {
     ContentsImageObject(
             size: '1024x1024',
             idiom: 'ios-marketing',
-            filename: fileNamePrefix + '-83.5x83.5@2x.png',
-            scale: '2x')
+            filename: fileNamePrefix + '-1024x1024@1x.png',
+            scale: '1x')
         .toJson()
   ];
   return imageList;


### PR DESCRIPTION
When specifying a new icon by setting the ios: config to a new icon name, the resulting assets file in XCode was showing 2 undefined icons and a missing AppStore icon. The App Store would also throw a warning upon file upload.

This change correctly assigns the app store icon and the icon assets file no longer has any superfluous entries.

Thanks for an awesome package!
