### PR TITLE
Fix #151 do not add extra newlines in manifest

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -266,8 +266,6 @@ List<String> transformAndroidManifestWithNewLauncherIcon(List<String> oldManifes
       line = line.replaceAll(RegExp(r'android:icon="[^"]*(\\"[^"]*)*"'),
           'android:icon="@mipmap/$iconName"');
       oldManifestLines[x] = line;
-      // used to stop git showing a diff if the icon name hasn't changed
-      oldManifestLines.add('');
     }
   }
   return oldManifestLines;

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -252,9 +252,10 @@ Future<void> overwriteAndroidManifestWithNewLauncherIcon(String iconName) async 
   final List<String> transformedLines = transformAndroidManifestWithNewLauncherIcon(oldManifestLines, iconName);
   await androidManifestFile.writeAsString(transformedLines.join('\n'));
 }
+
+/// Updates only the line containing android:icon with the specified iconName
 List<String> transformAndroidManifestWithNewLauncherIcon(List<String> oldManifestLines, String iconName) {
-  for (int x = 0; x < oldManifestLines.length; x++) {
-    String line = oldManifestLines[x];
+  return oldManifestLines.map((String line) {
     if (line.contains('android:icon')) {
       // Using RegExp replace the value of android:icon to point to the new icon
       // anything but a quote of any length: [^"]*
@@ -263,14 +264,13 @@ List<String> transformAndroidManifestWithNewLauncherIcon(List<String> oldManifes
       // repeat as often as wanted with no quote at start: [^"]*(\"[^"]*)*
       // escaping the slash to place in string: [^"]*(\\"[^"]*)*"
       // result: any string which does only include escaped quotes
-      line = line.replaceAll(RegExp(r'android:icon="[^"]*(\\"[^"]*)*"'),
+      return line.replaceAll(RegExp(r'android:icon="[^"]*(\\"[^"]*)*"'),
           'android:icon="@mipmap/$iconName"');
-      oldManifestLines[x] = line;
+    } else {
+      return line;
     }
-  }
-  return oldManifestLines;
+  }).toList();
 }
-
 
 /// Retrieves the minSdk value from the Android build.gradle file
 int minSdk() {

--- a/test/android_test.dart
+++ b/test/android_test.dart
@@ -49,4 +49,49 @@ void main() {
     expect(android.getAndroidIconPath(flutterIconsNewIconConfig),
         'assets/images/icon-android.png');
   });
+
+  test('Transforming manifest without icon must add icon', () {
+    final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"');
+    final String expectedManifest = getAndroidManifestExample('android:icon="@mipmap/ic_other_icon_name"');
+
+    final String actual = android.transformAndroidManifestWithNewLauncherIcon(
+        inputManifest.split('\n'), 'ic_other_icon_name').join('\n');
+    expect(actual, equals(expectedManifest));
+  });
+
+  test('Transforming manifest with icon already in place should leave it unchanged', () {
+    final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"');
+    final String actual = android.transformAndroidManifestWithNewLauncherIcon(inputManifest.split('\n'), 'ic_launcher')
+        .join('\n');
+    expect(actual, equals(inputManifest));
+  });
+}
+
+String getAndroidManifestExample(String iconLine) {
+  return '''
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.myapplication">
+
+    <application
+        android:allowBackup="true"
+        $iconLine
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+  '''.trim();
 }


### PR DESCRIPTION
This solves a problem that is (to us) really annoying: the code that updates the manifest always added a newline every single time. And because we ran it more often, this lead to multiple newlines added to our manifest, which then got committed to our codebase.

I fixed it - and as a bonus, I added 2 unit tests to check if we actually get the manifest transformation right 🎉  :-)