### PR TITLE
Fix: code was always getting rid of trailing \n

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -39,14 +39,14 @@ void createDefaultIcons(Map<String, dynamic> flutterLauncherIconsConfig) {
     for (AndroidIconTemplate template in androidIcons) {
       saveNewImages(template, image, iconPath);
     }
-    overwriteAndroidManifestWithNewLauncherIcon(iconName);
+    overwriteAndroidManifestWithNewLauncherIcon(iconName, File(constants.androidManifestFile));
   } else {
     print('Overwriting the default Android launcher icon with a new icon');
     for (AndroidIconTemplate template in androidIcons) {
       overwriteExistingIcons(template, image, constants.androidFileName);
     }
     overwriteAndroidManifestWithNewLauncherIcon(
-        constants.androidDefaultIconName);
+        constants.androidDefaultIconName, File(constants.androidManifestFile));
   }
 }
 
@@ -249,9 +249,9 @@ void saveNewImages(
 ///
 /// Note: default iconName = "ic_launcher"
 Future<void> overwriteAndroidManifestWithNewLauncherIcon(
-    String iconName) async {
-  final File androidManifestFile = File(constants.androidManifestFile);
-  final List<String> oldManifestLines = await androidManifestFile.readAsLines();
+    String iconName, File androidManifestFile) async {
+  // we do not use `file.readAsLinesSync()` here because that always gets rid of the last empty newline
+  final List<String> oldManifestLines = (await androidManifestFile.readAsString()).split('\n');
   final List<String> transformedLines = transformAndroidManifestWithNewLauncherIcon(oldManifestLines, iconName);
   await androidManifestFile.writeAsString(transformedLines.join('\n'));
 }

--- a/test/android_test.dart
+++ b/test/android_test.dart
@@ -1,6 +1,8 @@
-import 'package:test/test.dart';
+import 'dart:io';
+
 import 'package:flutter_launcher_icons/android.dart' as android;
 import 'package:flutter_launcher_icons/constants.dart';
+import 'package:test/test.dart';
 
 // unit tests for android.dart
 void main() {
@@ -50,21 +52,75 @@ void main() {
         'assets/images/icon-android.png');
   });
 
-  test('Transforming manifest without icon must add icon', () {
+  test('Transforming manifest without icon must add icon', () async {
     final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"');
     final String expectedManifest = getAndroidManifestExample('android:icon="@mipmap/ic_other_icon_name"');
 
-    final String actual = android.transformAndroidManifestWithNewLauncherIcon(
-        inputManifest.split('\n'), 'ic_other_icon_name').join('\n');
-    expect(actual, equals(expectedManifest));
+    await withTempFile('AndroidManifest.xml', (File androidManifestFile) async {
+      androidManifestFile.writeAsStringSync(inputManifest);
+      await android.overwriteAndroidManifestWithNewLauncherIcon('ic_other_icon_name', androidManifestFile);
+      expect(androidManifestFile.readAsStringSync(), equals(expectedManifest));
+    });
   });
 
-  test('Transforming manifest with icon already in place should leave it unchanged', () {
+  test('Transforming manifest with icon already in place should leave it unchanged', () async {
     final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"');
-    final String actual = android.transformAndroidManifestWithNewLauncherIcon(inputManifest.split('\n'), 'ic_launcher')
-        .join('\n');
-    expect(actual, equals(inputManifest));
+    final String expectedManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"');
+
+    await withTempFile('AndroidManifest.xml', (File androidManifestFile) async {
+      androidManifestFile.writeAsStringSync(inputManifest);
+      await android.overwriteAndroidManifestWithNewLauncherIcon('ic_launcher', androidManifestFile);
+      expect(androidManifestFile.readAsStringSync(), equals(expectedManifest));
+    });
   });
+
+  test('Transforming manifest with trailing newline should keep newline untouched', () async {
+    final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"') + '\n';
+    final String expectedManifest = inputManifest;
+
+    await withTempFile('AndroidManifest.xml', (File androidManifestFile) async {
+      androidManifestFile.writeAsStringSync(inputManifest);
+      await android.overwriteAndroidManifestWithNewLauncherIcon('ic_launcher', androidManifestFile);
+      expect(androidManifestFile.readAsStringSync(), equals(expectedManifest));
+    });
+  });
+
+  test('Transforming manifest with 3 trailing newlines should keep newlines untouched', () async {
+    final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"') + '\n\n\n';
+    final String expectedManifest = inputManifest;
+
+    await withTempFile('AndroidManifest.xml', (File androidManifestFile) async {
+      androidManifestFile.writeAsStringSync(inputManifest);
+      await android.overwriteAndroidManifestWithNewLauncherIcon('ic_launcher', androidManifestFile);
+      expect(androidManifestFile.readAsStringSync(), equals(expectedManifest));
+    });
+  });
+
+  test(
+      'Transforming manifest with special newline characters should leave special newline characters untouched', () async {
+    final String inputManifest = getAndroidManifestExample('android:icon="@mipmap/ic_launcher"').replaceAll(
+        '\n', '\r\n');
+    final String expectedManifest = inputManifest;
+
+    await withTempFile('AndroidManifest.xml', (File androidManifestFile) async {
+      androidManifestFile.writeAsStringSync(inputManifest);
+      await android.overwriteAndroidManifestWithNewLauncherIcon('ic_launcher', androidManifestFile);
+      expect(androidManifestFile.readAsStringSync(), equals(expectedManifest));
+    });
+  });
+}
+
+Future<void> withTempFile(String fileName, Function block) async {
+  final Directory tempDir = Directory.systemTemp.createTempSync();
+  final File file = File('${tempDir.path}/$fileName')..createSync();
+  if (!file.existsSync()) {
+    fail('Could not create temp test file ${file.path}');
+  }
+  try {
+    await block(file);
+  } finally {
+    file.deleteSync();
+  }
 }
 
 String getAndroidManifestExample(String iconLine) {


### PR DESCRIPTION
The code still had a bug (which I didn't cover in the tests), so a newline at the end of the file would always get removed. What I didn't know: `file.readAsLinesSync()` gets rid of the last empty newline, so we can't know if that was there or not.

Bonus: I added a new `withTempFile` method, that creates a temporary file during the tests and deletes that afterwards - really helpful for testing the full IO-roundtrip to AndroidManifest.xml files. All manifest tests now use that method and test the full thing.