### PR TITLE
add windows support to the flavor file pattern regex

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ import 'package:flutter_launcher_icons/custom_exceptions.dart';
 const String fileOption = 'file';
 const String helpFlag = 'help';
 const String defaultConfigFile = 'flutter_launcher_icons.yaml';
-const String flavorConfigFilePattern = '\./flutter_launcher_icons-(.*).yaml';
+const String flavorConfigFilePattern = r'[\\/]flutter_launcher_icons-(.*).yaml';
 String flavorConfigFile(String flavor) => 'flutter_launcher_icons-$flavor.yaml';
 
 List<String> getFlavors() {


### PR DESCRIPTION
File paths on Windows use back slashes instead of forward slashes so  the `flavorConfigFilePattern` regex wasn't picking up config files on Windows and thus behaving differently.