### PR TITLE
Append a newline at the end of project.pbxproj

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -133,6 +133,9 @@ Future<void> changeIosLauncherIcon(String iconName, String flavor) async {
     }
   }
 
+  // To append a newline at the end of the file.
+  lines.add('');
+
   final String entireFile = lines.join('\n');
   await iOSConfigFile.writeAsString(entireFile);
 }


### PR DESCRIPTION
The problem of producing newline diff reported in  https://github.com/fluttercommunity/flutter_launcher_icons/issues/43 still exists in v0.8.1. This PR fixed it.