### PR TITLE
Await all futures

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -159,6 +159,7 @@ linter:
     - type_init_formals
     # - unawaited_futures # too many false positives
     # - unnecessary_await_in_return # not yet tested
+    - unawaited_futures
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_getters_setters

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_launcher_icons/constants.dart';
 import 'package:flutter_launcher_icons/main.dart' as flutter_launcher_icons;
+import 'package:pedantic/pedantic.dart';
 
 void main(List<String> arguments) {
   print(introMessage('0.9.1'));
-  flutter_launcher_icons.createIconsFromArguments(arguments);
+  unawaited(flutter_launcher_icons.createIconsFromArguments(arguments));
 }

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -28,8 +28,8 @@ List<AndroidIconTemplate> androidIcons = <AndroidIconTemplate>[
   AndroidIconTemplate(directoryName: 'mipmap-xxxhdpi', size: 192),
 ];
 
-void createDefaultIcons(
-    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) {
+Future<void> createDefaultIcons(
+    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) async {
   printStatus('Creating default icons Android');
   final String filePath = getAndroidIconPath(flutterLauncherIconsConfig);
   final Image? image = decodeImageFile(filePath);
@@ -43,17 +43,18 @@ void createDefaultIcons(
     isAndroidIconNameCorrectFormat(iconName);
     final String iconPath = '$iconName.png';
     for (AndroidIconTemplate template in androidIcons) {
-      saveNewImages(template, image, iconPath, flavor);
+      await saveNewImages(template, image, iconPath, flavor);
     }
-    overwriteAndroidManifestWithNewLauncherIcon(iconName, androidManifestFile);
+    await overwriteAndroidManifestWithNewLauncherIcon(
+        iconName, androidManifestFile);
   } else {
     printStatus(
         'Overwriting the default Android launcher icon with a new icon');
     for (AndroidIconTemplate template in androidIcons) {
-      overwriteExistingIcons(
+      await overwriteExistingIcons(
           template, image, constants.androidFileName, flavor);
     }
-    overwriteAndroidManifestWithNewLauncherIcon(
+    await overwriteAndroidManifestWithNewLauncherIcon(
         constants.androidDefaultIconName, androidManifestFile);
   }
 }
@@ -68,8 +69,8 @@ bool isAndroidIconNameCorrectFormat(String iconName) {
   return true;
 }
 
-void createAdaptiveIcons(
-    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) {
+Future<void> createAdaptiveIcons(
+    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) async {
   printStatus('Creating adaptive icons Android');
 
   // Retrieve the necessary Flutter Launcher Icons configuration from the pubspec.yaml file
@@ -84,16 +85,16 @@ void createAdaptiveIcons(
 
   // Create adaptive icon foreground images
   for (AndroidIconTemplate androidIcon in adaptiveForegroundIcons) {
-    overwriteExistingIcons(androidIcon, foregroundImage,
+    await overwriteExistingIcons(androidIcon, foregroundImage,
         constants.androidAdaptiveForegroundFileName, flavor);
   }
 
   // Create adaptive icon background
   if (isAdaptiveIconConfigPngFile(backgroundConfig)) {
-    createAdaptiveBackgrounds(
+    await createAdaptiveBackgrounds(
         flutterLauncherIconsConfig, backgroundConfig, flavor);
   } else {
-    createAdaptiveIconMipmapXmlFile(flutterLauncherIconsConfig, flavor);
+   await createAdaptiveIconMipmapXmlFile(flutterLauncherIconsConfig, flavor);
     updateColorsXmlFile(backgroundConfig, flavor);
   }
 }
@@ -120,10 +121,10 @@ void updateColorsXmlFile(String backgroundConfig, String? flavor) {
 
 /// Creates the xml file required for the adaptive launcher icon
 /// FILE LOCATED HERE: res/mipmap-anydpi/{icon-name-from-yaml-config}.xml
-void createAdaptiveIconMipmapXmlFile(
-    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) {
+Future<void> createAdaptiveIconMipmapXmlFile(
+    Map<String, dynamic> flutterLauncherIconsConfig, String? flavor) async {
   if (isCustomAndroidFile(flutterLauncherIconsConfig)) {
-    File(constants.androidAdaptiveXmlFolder(flavor) +
+    await File(constants.androidAdaptiveXmlFolder(flavor) +
             getNewIconName(flutterLauncherIconsConfig) +
             '.xml')
         .create(recursive: true)
@@ -131,7 +132,7 @@ void createAdaptiveIconMipmapXmlFile(
       adaptiveIcon.writeAsString(xml_template.icLauncherXml);
     });
   } else {
-    File(constants.androidAdaptiveXmlFolder(flavor) +
+    await File(constants.androidAdaptiveXmlFolder(flavor) +
             constants.androidDefaultIconName +
             '.xml')
         .create(recursive: true)
@@ -142,8 +143,8 @@ void createAdaptiveIconMipmapXmlFile(
 }
 
 /// creates adaptive background using png image
-void createAdaptiveBackgrounds(Map<String, dynamic> yamlConfig,
-    String adaptiveIconBackgroundImagePath, String? flavor) {
+Future<void> createAdaptiveBackgrounds(Map<String, dynamic> yamlConfig,
+    String adaptiveIconBackgroundImagePath, String? flavor) async {
   final String filePath = adaptiveIconBackgroundImagePath;
   final Image? image = decodeImageFile(filePath);
   if (image == null) {
@@ -153,14 +154,14 @@ void createAdaptiveBackgrounds(Map<String, dynamic> yamlConfig,
   // creates a png image (ic_adaptive_background.png) for the adaptive icon background in each of the locations
   // it is required
   for (AndroidIconTemplate androidIcon in adaptiveForegroundIcons) {
-    saveNewImages(androidIcon, image,
+    await saveNewImages(androidIcon, image,
         constants.androidAdaptiveBackgroundFileName, flavor);
   }
 
   // Creates the xml file required for the adaptive launcher icon
   // FILE LOCATED HERE:  res/mipmap-anydpi/{icon-name-from-yaml-config}.xml
   if (isCustomAndroidFile(yamlConfig)) {
-    File(constants.androidAdaptiveXmlFolder(flavor) +
+    await File(constants.androidAdaptiveXmlFolder(flavor) +
             getNewIconName(yamlConfig) +
             '.xml')
         .create(recursive: true)
@@ -168,7 +169,7 @@ void createAdaptiveBackgrounds(Map<String, dynamic> yamlConfig,
       adaptiveIcon.writeAsString(xml_template.icLauncherDrawableBackgroundXml);
     });
   } else {
-    File(constants.androidAdaptiveXmlFolder(flavor) +
+    await File(constants.androidAdaptiveXmlFolder(flavor) +
             constants.androidDefaultIconName +
             '.xml')
         .create(recursive: true)
@@ -179,8 +180,8 @@ void createAdaptiveBackgrounds(Map<String, dynamic> yamlConfig,
 }
 
 /// Creates a colors.xml file if it was missing from android/app/src/main/res/values/colors.xml
-void createNewColorsFile(String backgroundColor, String? flavor) {
-  File(constants.androidColorsFile(flavor))
+Future<void> createNewColorsFile(String backgroundColor, String? flavor) async {
+  await File(constants.androidColorsFile(flavor))
       .create(recursive: true)
       .then((File colorsFile) {
     colorsFile.writeAsString(xml_template.colorsXml).then((File file) {
@@ -231,14 +232,14 @@ String getNewIconName(Map<String, dynamic> config) {
 /// Note: Do not change interpolation unless you end up with better results (see issue for result when using cubic
 /// interpolation)
 /// https://github.com/fluttercommunity/flutter_launcher_icons/issues/101#issuecomment-495528733
-void overwriteExistingIcons(
+Future<void> overwriteExistingIcons(
   AndroidIconTemplate template,
   Image image,
   String filename,
   String? flavor,
-) {
+) async {
   final Image newFile = createResizedImage(template.size, image);
-  File(constants.androidResFolder(flavor) +
+  await File(constants.androidResFolder(flavor) +
           template.directoryName +
           '/' +
           filename)
@@ -251,10 +252,10 @@ void overwriteExistingIcons(
 /// Saves new launcher icons to the project, keeping the old launcher icons.
 /// Note: Do not change interpolation unless you end up with better results
 /// https://github.com/fluttercommunity/flutter_launcher_icons/issues/101#issuecomment-495528733
-void saveNewImages(AndroidIconTemplate template, Image image,
-    String iconFilePath, String? flavor) {
+Future<void> saveNewImages(AndroidIconTemplate template, Image image,
+    String iconFilePath, String? flavor) async {
   final Image newFile = createResizedImage(template.size, image);
-  File(constants.androidResFolder(flavor) +
+  await File(constants.androidResFolder(flavor) +
           template.directoryName +
           '/' +
           iconFilePath)

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -30,7 +30,7 @@ List<IosIconTemplate> iosIcons = <IosIconTemplate>[
   IosIconTemplate(name: '-1024x1024@1x', size: 1024),
 ];
 
-void createIcons(Map<String, dynamic> config, String? flavor) {
+Future<void> createIcons(Map<String, dynamic> config, String? flavor) async {
   final String filePath = config['image_path_ios'] ?? config['image_path'];
   // decodeImageFile shows error message if null
   // so can return here if image is null
@@ -50,10 +50,10 @@ void createIcons(Map<String, dynamic> config, String? flavor) {
     final String catalogName = 'AppIcon-$flavor';
     printStatus('Building iOS launcher icon for $flavor');
     for (IosIconTemplate template in iosIcons) {
-      saveNewIcons(template, image, catalogName);
+      await saveNewIcons(template, image, catalogName);
     }
     iconName = iosDefaultIconName;
-    changeIosLauncherIcon(catalogName, flavor);
+    await changeIosLauncherIcon(catalogName, flavor);
     modifyContentsFile(catalogName);
   } else if (iosConfig is String) {
     // If the IOS configuration is a string then the user has specified a new icon to be created
@@ -61,10 +61,10 @@ void createIcons(Map<String, dynamic> config, String? flavor) {
     final String newIconName = iosConfig;
     printStatus('Adding new iOS launcher icon');
     for (IosIconTemplate template in iosIcons) {
-      saveNewIcons(template, image, newIconName);
+      await saveNewIcons(template, image, newIconName);
     }
     iconName = newIconName;
-    changeIosLauncherIcon(iconName, flavor);
+    await changeIosLauncherIcon(iconName, flavor);
     modifyContentsFile(iconName);
   }
   // Otherwise the user wants the new icon to use the default icons name and
@@ -75,7 +75,7 @@ void createIcons(Map<String, dynamic> config, String? flavor) {
       overwriteDefaultIcons(template, image);
     }
     iconName = iosDefaultIconName;
-    changeIosLauncherIcon('AppIcon', flavor);
+    await changeIosLauncherIcon('AppIcon', flavor);
   }
 }
 
@@ -91,10 +91,11 @@ void overwriteDefaultIcons(IosIconTemplate template, Image image) {
 /// Note: Do not change interpolation unless you end up with better results (see issue for result when using cubic
 /// interpolation)
 /// https://github.com/fluttercommunity/flutter_launcher_icons/issues/101#issuecomment-495528733
-void saveNewIcons(IosIconTemplate template, Image image, String newIconName) {
+Future<void> saveNewIcons(
+    IosIconTemplate template, Image image, String newIconName) async {
   final String newIconFolder = iosAssetFolder + newIconName + '.appiconset/';
   final Image newFile = createResizedImage(template, image);
-  File(newIconFolder + newIconName + template.name + '.png')
+  await File(newIconFolder + newIconName + template.name + '.png')
       .create(recursive: true)
       .then((File file) {
     file.writeAsBytesSync(encodePng(newFile));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,7 +57,7 @@ Future<void> createIconsFromArguments(List<String> arguments) async {
   // Create icons
   if (!hasFlavors) {
     try {
-      createIconsFromConfig(yamlConfig);
+      await createIconsFromConfig(yamlConfig);
       print('\n✓ Successfully generated launcher icons');
     } catch (e) {
       stderr.writeln('\n✕ Could not generate launcher icons');
@@ -100,13 +100,13 @@ Future<void> createIconsFromConfig(Map<String, dynamic> config,
   }
 
   if (isNeedingNewAndroidIcon(config)) {
-    android_launcher_icons.createDefaultIcons(config, flavor);
+    await android_launcher_icons.createDefaultIcons(config, flavor);
   }
   if (hasAndroidAdaptiveConfig(config)) {
-    android_launcher_icons.createAdaptiveIcons(config, flavor);
+    await android_launcher_icons.createAdaptiveIcons(config, flavor);
   }
   if (isNeedingNewIOSIcon(config)) {
-    ios_launcher_icons.createIcons(config, flavor);
+    await ios_launcher_icons.createIcons(config, flavor);
   }
 }
 


### PR DESCRIPTION
Hello and thank you for the library,

The function `createIconsFromArguments` exposed in `main.dart` returns a Future, so users expect that the task will be fully done when the Future completes, but it currently isn't the case.

**How to reproduce**
I noticed this because I am using the plugin in a dart CLI application, as one of our build steps. I am calling `exit(0)` after the Future completes, which causes the plugin to not write images to disk.
```dart
await createIconsFromArguments([]);
// images have not been written to disk at this point
exit(0)
// application exits without images 
```

**Cause**
This bug is due to the fact that many Futures are currently not awaited, which is hard to spot because they are called from synchronous functions.

**Fix**
I have tried to spot all the Futures and to await them, but it could be that I forgot some.
I also added the [unawaited_futures](https://dart-lang.github.io/linter/lints/unawaited_futures.html) lint rule. 

**Tested**
I have tested this change in our build process and it all works fine: images are written to disk when the `createIconsFromArguments` completes.

**Caveat / Question**
I wonder if this could affect the overall performance of the current implementation, since functions will be executed sequentially, while they are maybe executed concurrently in the current implementation?