### PR TITLE
Fix FormatException on latest flutter configuration files

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -306,7 +306,11 @@ int minSdk() {
     if (line.contains('minSdkVersion')) {
       // remove anything from the line that is not a digit
       final String minSdk = line.replaceAll(RegExp(r'[^\d]'), '');
-      return int.parse(minSdk);
+      try {
+        return int.parse(minSdk);
+      } on FormatException catch (_) {
+        printStatus("minSdk '${minSdk}' cannot be parsed as int ");
+      }
     }
   }
   return 0; // Didn't find minSdk, assume the worst


### PR DESCRIPTION
Fixing this error on new flutter configs 
```
  ════════════════════════════════════════════
     FLUTTER LAUNCHER ICONS (v0.9.1)
  ════════════════════════════════════════════


✓ Successfully generated launcher icons
Unhandled exception:
FormatException: Invalid number (at character 1)

^

#0      int._handleFormatError (dart:core-patch/integers_patch.dart:129:7)
#1      int.parse (dart:core-patch/integers_patch.dart:55:14)
#2      minSdk (package:flutter_launcher_icons/android.dart:309:18)
#3      createIconsFromConfig (package:flutter_launcher_icons/main.dart:94:47)
#4      createIconsFromArguments (package:flutter_launcher_icons/main.dart:60:7)
#5      main (file:///Users/marcobazzani/Projects/flutter_launcher_icons/bin/main.dart:6:26)
#6      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:32)
#7      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
```