### PR TITLE
fix: Incorrect version number shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.3 (6th June 2022)
+
+- Fixes to make sure it works for Flutter v2.8 (thanks to @RatakondalaArun)
+- Fixed issue with incorrect version being shown
+
 ## 0.9.2 (22nd August 2021)
 
 - Fixed issue where success message printed even when exception occured (thanks to @happy-san)

--- a/README.md
+++ b/README.md
@@ -6,35 +6,6 @@
 
 A command-line tool which simplifies the task of updating your Flutter app's launcher icon. Fully flexible, allowing you to choose what platform you wish to update the launcher icon for and if you want, the option to keep your old launcher icon in case you want to revert back sometime in the future.
 
-
-## :sparkles: What's New
-
-#### Version 0.9.2 (22nd August 2021)
-
-- Fixed issue where success message printed even when exception occured (thanks to @happy-san)
-
-#### Version 0.9.1 (25th July 2021)
-
-- Upgraded `args` dependency to ^2.1.1 (thanks to @PiN73 and @comlaterra)
-- Upgraded `image` and `test` dependencies
-
-#### Version 0.9.0 (28th Feb 2021)
-
-- Null-safety support added (thanks to @SteveAlexander)
-- Added option to remove alpha channel for iOS icons (thanks to @SimonIT)
-
-#### Version 0.8.1 (2nd Oct 2020)
-
-- Fixed flavor support on windows (@slightfoot)
-
-#### Version 0.8.0 (12th Sept 2020)
-
-- Added flavours support (thanks to @sestegra & @jorgecoca)
-- Removed unassigned iOS icons (thanks to @melvinsalas)
-- Fixing formatting (thanks to @mreichelt)
-
-Want to see older changes? Be sure to check out the [Changelog](https://github.com/fluttercommunity/flutter_launcher_icons/blob/master/CHANGELOG.md).
-
 ## :book: Guide
 
 #### 1. Setup the config file

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,23 +1,3 @@
-# Specify analysis options.
-#
-# Until there are meta linter rules, each desired lint must be explicitly enabled.
-# See: https://github.com/dart-lang/linter/issues/288
-#
-# For a list of lints, see: http://dart-lang.github.io/linter/lints/
-# See the configuration guide for more
-# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
-#
-# There are other similar analysis options files in the flutter repos,
-# which should be kept in sync with this file:
-#
-#   - analysis_options.yaml (this file)
-#   - packages/flutter/lib/analysis_options_user.yaml
-#   - https://github.com/flutter/plugins/blob/master/analysis_options.yaml
-#   - https://github.com/flutter/engine/blob/master/analysis_options.yaml
-#
-# This file contains the analysis options used by Flutter tools, such as IntelliJ,
-# Android Studio, and the `flutter analyze` command.
-
 analyzer:
   strong-mode:
     implicit-dynamic: false
@@ -51,7 +31,6 @@ linter:
     - always_require_non_null_named_parameters
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
     # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_launcher_icons/constants.dart';
 import 'package:flutter_launcher_icons/main.dart' as flutter_launcher_icons;
+import 'package:flutter_launcher_icons/src/version.dart';
 
 void main(List<String> arguments) {
-  print(introMessage('0.9.1'));
+  print(introMessage(packageVersion));
   flutter_launcher_icons.createIconsFromArguments(arguments);
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '0.9.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_launcher_icons
 description: A package which simplifies the task of updating your Flutter app's launcher icon.
-version: 0.9.2
+version: 0.9.3
 maintainer: Mark O'Sullivan (@MarkOSullivan94)
 homepage: https://github.com/fluttercommunity/flutter_launcher_icons
 
@@ -14,4 +14,9 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.17.11
+  # Needed by build_version
+  build_runner: 2.1.11
+  # allows us to get version number from pubspec yaml which we can pass to Sentry
+  # https://pub.dev/packages/build_version
+  build_version: ^2.1.1
+  test: ^1.21.1


### PR DESCRIPTION
Thanks to build_version and build_runner the version number is automatically generated after running build_runner and should _hopefully_ be easier to update.

Also removed What's New section from README as this is pretty much duplicating what is shown in CHANGELOG file.

Closes: #350