### PR TITLE
fix: ignore commented minSdkVersion

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -317,6 +317,10 @@ int getMinSdkFromFile(File file) {
   final List<String> lines = file.readAsLinesSync();
   for (String line in lines) {
     if (line.contains('minSdkVersion')) {
+      if (line.contains('//') && line.indexOf('//') < line.indexOf('minSdkVersion')) {
+        // This line is commented
+        continue;
+      }
       // remove anything from the line that is not a digit
       final String minSdk = line.replaceAll(RegExp(r'[^\d]'), '');
       // when minSdkVersion value not found


### PR DESCRIPTION
Running the flutter_launcher_icons script was failing because I had a commented line in my `build.gradle` file:
```
    defaultConfig {
        // minSdkVersion flutter.minSdkVersion
        minSdkVersion 19
    }
```

This small patch will already fix that issue.

Another issue is going to be the fact that `flutter.minSdkVersion` won't be resolved correctly. I already commented it out because that was giving me issues for something else (I think codemagic.io setup, but I'm not sure anymore). However, for now this will do and I don't really feel up to the task yet to tackle the "properties replacement" issue. Still, I might turn that into a feature request later on.