### PR TITLE
Optionally specify min_sdk in pubspec.yaml or flutter_launcher_icons.yaml

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -299,17 +299,30 @@ List<String> transformAndroidManifestWithNewLauncherIcon(
 }
 
 /// Retrieves the minSdk value from the Android build.gradle file or local.properties file
-int minSdk() {
+int minSdk(Map<String, dynamic> config) {
   final androidGradleFile = File(constants.androidGradleFile);
   final androidLocalPropertiesFile = File(constants.androidLocalPropertiesFile);
 
   // look in build.gradle first
-  final minSdkValue = getMinSdkFromFile(androidGradleFile);
+  var minSdkValue = getMinSdkFromFile(androidGradleFile);
 
-  // look in local.properties. Didn't find minSdk, assume the worst
-  return minSdkValue != 0
-      ? minSdkValue
-      : getMinSdkFromFile(androidLocalPropertiesFile);
+  if (minSdkValue != 0) {
+    return minSdkValue;
+  }
+
+  // then look in local.properties.
+  minSdkValue = getMinSdkFromFile(androidLocalPropertiesFile);
+
+  if (minSdkValue != 0) {
+    return minSdkValue;
+  }
+
+  // finally look in the pubspec.yaml or flutter_launcher_icons.yaml
+  minSdkValue = (config.containsKey('min_sdk') && config['min_sdk'] is int)
+      ? config['min_sdk']
+      : 0;
+
+  return minSdkValue;
 }
 
 /// Retrieves the minSdk value from [File]

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -25,9 +25,13 @@ const String errorMissingPlatform =
 const String errorMissingRegularAndroid =
     'Adaptive icon config found but no regular Android config. '
     'Below API 26 the regular Android config is required';
-const String errorMissingMinSdk =
-    'Cannot not find minSdk from android/app/build.gradle or android/local.properties'
-    'Specify minSdk in either android/app/build.gradle or android/local.properties';
+const String errorMissingMinSdk = '''
+Cannot find minSdk in android/app/build.gradle or android/local.properties.
+Cannot find min_sdk in pubspec.yaml or flutter_launcher_icons.yaml
+Specify minSdk in android/app/build.gradle or android/local.properties
+-- or --
+Specify min_sdk in pubspec.yaml or flutter_launcher_icons.yaml
+''';
 const String errorIncorrectIconName =
     'The icon name must contain only lowercase a-z, 0-9, or underscore: '
     'E.g. "ic_my_new_icon"';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,7 +91,7 @@ Future<void> createIconsFromConfig(Map<String, dynamic> config,
   }
 
   if (isNeedingNewAndroidIcon(config) || hasAndroidAdaptiveConfig(config)) {
-    final int minSdk = android_launcher_icons.minSdk();
+    final int minSdk = android_launcher_icons.minSdk(config);
     if (minSdk == 0) {
       throw const InvalidConfigException(errorMissingMinSdk);
     }


### PR DESCRIPTION
This pull request enables the possibility of defining the min sdk in the `pubspec.yaml` or 'flutter_launcher_icons.yaml` 
``` yaml
flutter_icons:
  min_sdk: 16
```

#330
#324 
#371