### PR TITLE
add .pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,8 @@
+# test directory
+/test/*
+
+# markdown files
+/CHANGELOG.md
+
+# other
+/flutter_launcher_icons.code-workspace


### PR DESCRIPTION
this handles part of https://github.com/fluttercommunity/flutter_launcher_icons/issues/379

## Not ignored:
- `pubspec.yaml` needed for PUBlishing.
- `LICENSE` due to license agreement.
- `analysis_options.yaml` for pub.dev to perform code analyze.
- `.gitignore` & `.github` because they are not present in files from pub.dev.

## Files I would leave in, because some may look at the zip they can download them from pub.dev.
- `/example/*`
- `/README.md`

This is a little open to discussion, but as also as easy to change.