### PR TITLE
upgrades dependencies: Makes it compatible with the latest version of flutter_native_splash

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -6,7 +6,7 @@ import 'package:flutter_launcher_icons/custom_exceptions.dart';
 import 'package:flutter_launcher_icons/flutter_launcher_icons_config.dart';
 import 'package:flutter_launcher_icons/utils.dart';
 import 'package:flutter_launcher_icons/xml_templates.dart' as xml_template;
-import 'package:image/image.dart';
+import 'package:image/image.dart' hide decodeImageFile;
 import 'package:path/path.dart' as path;
 
 class AndroidIconTemplate {

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -52,9 +52,12 @@ void createIcons(FlutterLauncherIconsConfig config, String? flavor) {
     return;
   }
   if (config.removeAlphaIOS) {
-    image.channels = Channels.rgb;
+    image.remapChannels(ChannelOrder.rgb);
   }
-  if (image.channels == Channels.rgba) {
+
+  /// RGBA has 4 channels and RGB has 3 channels
+  /// Therefore, if the number of channels is 4 then the image has an alpha channel
+  if (image.numChannels == 4) {
     print(
       '\nWARNING: Icons with alpha channel are not allowed in the Apple App Store.\nSet "remove_alpha_ios: true" to remove it.\n',
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,13 +7,13 @@ repository: https://github.com/fluttercommunity/flutter_launcher_icons/
 issue_tracker: https://github.com/fluttercommunity/flutter_launcher_icons/issues
 
 dependencies:
-  args: ^2.2.0
-  checked_yaml: ^2.0.1
+  args: ^2.3.1
+  checked_yaml: ^2.0.2
   cli_util: ^0.3.5
-  image: ^3.0.2
-  json_annotation: ^4.5.0
-  path: ^1.8.0
-  yaml: ^3.1.0
+  image: ^4.0.10
+  json_annotation: ^4.7.0
+  path: ^1.8.3
+  yaml: ^3.1.1
 
 environment:
   sdk: '>=2.13.0 <3.0.0'


### PR DESCRIPTION
The biggest change coming with upgrading dependencies is `image: 3.0.2` -> `image: 4.0.10` - which caused the API for settings and checking the channels of an image slightly.

All tests are passing. 