### PR TITLE
Fix remove alpha for iOS

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -54,12 +54,12 @@ void createIcons(FlutterLauncherIconsConfig config, String? flavor) {
   }
   // decodeImageFile shows error message if null
   // so can return here if image is null
-  final Image? image = decodeImage(File(filePath).readAsBytesSync());
+  Image? image = decodeImage(File(filePath).readAsBytesSync());
   if (image == null) {
     return;
   }
-  if (config.removeAlphaIOS) {
-    image.remapChannels(ChannelOrder.rgb);
+  if (config.removeAlphaIOS && image.hasAlpha) {
+    image = image.convert(numChannels: 3);
   }
   if (image.hasAlpha) {
     print(


### PR DESCRIPTION
Fix for #462.

After the dependency upgrade from image 3.x.x to image 4.0.x the remove alpha for iOS no longer works and builds are rejected from the App Store.
The fix is from the example here: https://github.com/brendan-duncan/image/issues/447#issuecomment-1374543054.

All tests are passing.