### PR TITLE
style: formatted code with `dart format .`

### DIFF
--- a/lib/custom_exceptions.dart
+++ b/lib/custom_exceptions.dart
@@ -4,6 +4,7 @@ import 'package:flutter_launcher_icons/utils.dart';
 class InvalidConfigException implements Exception {
   /// Constructs instance
   const InvalidConfigException([this.message]);
+
   /// Message for the exception
   final String? message;
 
@@ -17,6 +18,7 @@ class InvalidConfigException implements Exception {
 class InvalidAndroidIconNameException implements Exception {
   /// Constructs instance of this exception
   const InvalidAndroidIconNameException([this.message]);
+
   /// Message for the exception
   final String? message;
 
@@ -30,6 +32,7 @@ class InvalidAndroidIconNameException implements Exception {
 class NoConfigFoundException implements Exception {
   /// Constructs instance of this exception
   const NoConfigFoundException([this.message]);
+
   /// Message for the exception
   final String? message;
 
@@ -43,6 +46,7 @@ class NoConfigFoundException implements Exception {
 class NoDecoderForImageFormatException implements Exception {
   /// Constructs instance of this exception
   const NoDecoderForImageFormatException([this.message]);
+
   /// Message for the exception
   final String? message;
 

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -16,6 +16,7 @@ class IosIconTemplate {
 
   /// suffix of the icon name
   final String name;
+
   /// the size of the icon
   final int size;
 }
@@ -194,7 +195,6 @@ String generateContentsFileAsString(String newIconName) {
   };
   return json.encode(contentJson);
 }
-
 
 class ContentsImageObject {
   ContentsImageObject({

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:flutter_launcher_icons/web/web_icon_generator.dart';
 import 'package:flutter_launcher_icons/windows/windows_icon_generator.dart';
 import 'package:path/path.dart' as path;
 
-
 const String fileOption = 'file';
 const String helpFlag = 'help';
 const String verboseFlag = 'verbose';

--- a/test/macos/macos_icon_generator_test.dart
+++ b/test/macos/macos_icon_generator_test.dart
@@ -17,7 +17,6 @@ import '../templates.dart' as templates;
   MockSpec<MacOSConfig>(),
   MockSpec<FLILogger>(),
 ])
-
 import 'macos_icon_generator_test.mocks.dart';
 
 void main() {


### PR DESCRIPTION
Complying with dart code formatting.

Increases score on pub.dev site.

<img width="838" alt="Screenshot 2023-04-07 at 7 53 42 PM" src="https://user-images.githubusercontent.com/74326345/230625164-95d6ad3c-766b-4ccb-bc24-942be39cc39c.png">
