### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An example is shown below. More complex examples [can be found in the example pr
 dev_dependencies:
   flutter_launcher_icons: "^0.13.1"
 
-flutter_launcher_icons:
+flutter_icons:
   android: "launcher_icon"
   ios: true
   image_path: "assets/icon/icon.png"


### PR DESCRIPTION
`flutter_launcher_icons` key should be `flutter_icons` is misleading users
```
flutter_icons: # not flutter_launcher_icons
  android: "launcher_icon"
  ios: true
  image_path: "assets/icon/icon.png"
  min_sdk_android: 21 # android min sdk min:16, default 21
  web:
    generate: true
    image_path: "path/to/image.png"
    background_color: "#hexcode"
    theme_color: "#hexcode"
  windows:
    generate: true
    image_path: "path/to/image.png"
    icon_size: 48 # min:48, max:256, default: 48
  macos:
    generate: true
    image_path: "path/to/image.png"
```