### PR TITLE
Update 'flutter pub' run to 'dart run'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 0.13.1 (15th April 2023)
 
 - Can now use `flutter_launcher_icons` instead of `flutter_icons` [#478](https://github.com/fluttercommunity/flutter_launcher_icons/pull/478)
-- Can use command `flutter pub run flutter_launcher_icons:generate` to automatically generate config file [#475](https://github.com/fluttercommunity/flutter_launcher_icons/pull/475)
-
+- Can use command `dart run flutter_launcher_icons:generate` to automatically generate config file [#475](https://github.com/fluttercommunity/flutter_launcher_icons/pull/475)
 
 ## 0.13.0 (7th April 2023)
 
@@ -17,7 +16,7 @@
 - Updated image package and other packages [#447](https://github.com/fluttercommunity/flutter_launcher_icons/pull/447)
 
 ## 0.11.0 (27th September 2022)
-    
+
 - Support for Macos Icons [#407](https://github.com/fluttercommunity/flutter_launcher_icons/pull/407)
 - Cli-improvement [#400](https://github.com/fluttercommunity/flutter_launcher_icons/pull/400)
 - Add `repository` and `issue_tracker` [#411](https://github.com/fluttercommunity/flutter_launcher_icons/pull/411) (thanks to [@patelpathik](https://github.com/patelpathik))
@@ -137,7 +136,7 @@
 
 ## 0.3.0 (1st May 2018)
 
-- Fixed issue where icons produced weren't the correct size (Due to images not with a 1:1 aspect r    ation)
+- Fixed issue where icons produced weren't the correct size (Due to images not with a 1:1 aspect r ation)
 - Improved quality of smaller icons produced (Thanks to PR #17 - Thank you!)
 - Updated console printed messages to keep them consistent
 - Added example folder to GitHub project

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A command-line tool which simplifies the task of updating your Flutter app's lau
 Run the following command to create a new config automatically:
 
 ```shell
-flutter pub run flutter_launcher_icons:generate
+dart run flutter_launcher_icons:generate
 ```
 
 This will create a new file called `flutter_launcher_icons.yaml` in your `flutter` project's root directory.
@@ -21,13 +21,13 @@ This will create a new file called `flutter_launcher_icons.yaml` in your `flutte
 If you want to override the default location or name of the config file, use the `-f` flag:
 
 ```shell
-flutter pub run flutter_launcher_icons:generate -f <your config file name here>
+dart run flutter_launcher_icons:generate -f <your config file name here>
 ```
 
 To override an existing config file, use the `-o` flag:
 
 ```shell
-flutter pub run flutter_launcher_icons:generate -o
+dart run flutter_launcher_icons:generate -o
 ```
 
 OR
@@ -64,7 +64,7 @@ After setting up the configuration, all that is left to do is run the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons
+dart run flutter_launcher_icons
 ```
 
 If you name your configuration file something other than `flutter_launcher_icons.yaml` or `pubspec.yaml` you will need to specify
@@ -72,7 +72,7 @@ the name of the file when running the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons -f <your config file name here>
+dart run flutter_launcher_icons -f <your config file name here>
 ```
 
 Note: If you are not using the existing `pubspec.yaml` ensure that your config file is located in the same directory as it.

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -10,7 +10,7 @@ const _defaultConfigFileName = './flutter_launcher_icons.yaml';
 /// The function will be called from command line
 /// using the following command:
 /// ```sh
-/// flutter pub run flutter_launcher_icons:generate
+/// dart run flutter_launcher_icons:generate
 /// ```
 ///
 /// Calling this function will generate a flutter_launcher_icons.yaml file
@@ -73,7 +73,7 @@ void _generateConfigFile(File configFile) {
     print('\nConfig file generated successfully 🎉');
     print(
       'You can now use this new config file by using the command below:\n\n'
-      'flutter pub run flutter_launcher_icons'
+      'dart run flutter_launcher_icons'
       '${configFile.path == _defaultConfigFileName ? '' : ' -f ${configFile.path}'}\n',
     );
   } on Exception catch (e) {
@@ -82,7 +82,7 @@ void _generateConfigFile(File configFile) {
 }
 
 const _configFileTemplate = '''
-# flutter pub run flutter_launcher_icons
+# dart run flutter_launcher_icons
 flutter_launcher_icons:
   image_path: "assets/icon/icon.png"
 


### PR DESCRIPTION
The `flutter pub run` command is no longer supported in Flutter `2.10.0` and later. You should use the `dart run` command instead. The `flutter pub run` command was used to run Dart scripts that were published to pub.dev. However, this command was not always reliable and could sometimes cause problems. The dart run command is a more reliable way to run Dart scripts, and it also supports a wider range of features.

Using `flutter pub run` will show "_Deprecated. Use dart run instead_".