### PR TITLE
docs: command for multiple config files for flavors

### DIFF
--- a/example/flavors/README.md
+++ b/example/flavors/README.md
@@ -15,3 +15,18 @@ This project has the following flavors:
 - production: `flutter run --flavor production`
 - development: `flutter run --flavor development`
 - integration: `flutter run --flavor integration`
+
+## Command for running with multiple config files:
+
+In this project, we have three config files for our three flavors, namely: 
+ - flutter_launcer_icons-production
+ - flutter_launcer_icons-development
+ - flutter_launcer_icons-integration
+
+To run flutter_launcher_icons CLI, use the following command:
+
+```
+flutter pub run flutter_launcher_icons -f flutter_launcher_icons*
+```
+
+this means: run flutter_launcher_icons CLI for all files that start with `flutter_launcher_icons` followed by any characters, denoted by * (asterisk)


### PR DESCRIPTION
Ideally, when using flavors we have multiple config files for our flutter_launcher_icons.

This PR adds a command to help the future reader quickly run the flutter_launcher_icons CLI to use all config files together in a single command.