### PR TITLE
feat: add support for moving Xcode dir on iOS

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,10 +8,6 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
   exclude:
     - "bin/cache/**"
     # the following two are relative to the stocks example and the flutter package respectively
@@ -55,10 +51,9 @@ linter:
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
-    - list_remove_unrelated_type
+    - collection_methods_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,22 +1,21 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 /// Relative path to android resource folder
-String androidResFolder(String? flavor) =>
-    "android/app/src/${flavor ?? 'main'}/res/";
+String androidResFolder(String? flavor) => "android/app/src/${flavor ?? 'main'}/res/";
 
 /// Relative path to android colors.xml file
-String androidColorsFile(String? flavor) =>
-    "android/app/src/${flavor ?? 'main'}/res/values/colors.xml";
+String androidColorsFile(String? flavor) => "android/app/src/${flavor ?? 'main'}/res/values/colors.xml";
 
 const String androidManifestFile = 'android/app/src/main/AndroidManifest.xml';
 const String androidGradleFile = 'android/app/build.gradle';
 const String androidLocalPropertiesFile = 'android/local.properties';
 
 /// Relative path to flutter.gradle from flutter sdk path
-const String androidFlutterGardlePath =
-    'packages/flutter_tools/gradle/flutter.gradle';
+const String androidFlutterGardlePath = 'packages/flutter_tools/gradle/flutter.gradle';
 
 /// Default min_sdk value for android
 /// https://github.com/flutter/flutter/blob/master/packages/flutter_tools/gradle/flutter.gradle#L35-L37
@@ -24,14 +23,39 @@ const int androidDefaultAndroidMinSDK = 21;
 const String androidFileName = 'ic_launcher.png';
 const String androidAdaptiveForegroundFileName = 'ic_launcher_foreground.png';
 const String androidAdaptiveBackgroundFileName = 'ic_launcher_background.png';
-String androidAdaptiveXmlFolder(String? flavor) =>
-    androidResFolder(flavor) + 'mipmap-anydpi-v26/';
+String androidAdaptiveXmlFolder(String? flavor) => androidResFolder(flavor) + 'mipmap-anydpi-v26/';
 const String androidDefaultIconName = 'ic_launcher';
 
-const String iosDefaultIconFolder =
-    'ios/Runner/Assets.xcassets/AppIcon.appiconset/';
-const String iosAssetFolder = 'ios/Runner/Assets.xcassets/';
-const String iosConfigFile = 'ios/Runner.xcodeproj/project.pbxproj';
+/// Locates the iOS project folder based on some [sentinel] file.
+///
+/// For instance, to find [iosConfigFile]'s directory, use:
+/// ```dart
+/// getIosProjectName('project.pbxproj');
+/// ```
+///
+/// Or, to find [iosAssetFolder]'s directory, use:
+/// ```dart
+/// getIosProjectName('Assets.xcassets');
+/// ```
+///
+/// In the event that the sentinel file is not found, the [orElse] parameter
+/// can be used to specify a default, fallback, value. This defaults to 'Runner',
+/// which is the historic default iOS project name for Flutter.
+String getIosProjectName(final String sentinel, {final String orElse = 'Runner'}) =>
+    Directory('ios').listSync().map((final FileSystemEntity child) {
+      if (child is! Directory) {
+        return null;
+      }
+
+      if (child.listSync().any((possibleSentinel) => possibleSentinel.path.endsWith(sentinel))) {
+        return path.basename(child.path);
+      }
+    }).firstWhere((element) => element != null, orElse: () => null) ??
+    orElse;
+
+String getIosDefaultIconFolder() => 'ios/${getIosProjectName('Assets.xcassets')}/Assets.xcassets/AppIcon.appiconset/';
+String getIosAssetFolder() => 'ios/${getIosProjectName('Assets.xcassets')}/Assets.xcassets/';
+String getIosConfigFile() => 'ios/${getIosProjectName('project.pbxproj', orElse: 'Runner.xcodeproj')}/project.pbxproj';
 const String iosDefaultIconName = 'Icon-App';
 
 // web
@@ -61,8 +85,7 @@ String pubspecFilePath = path.join('pubspec.yaml');
 String windowsDirPath = path.join('windows');
 
 /// Relative path to windows resources directory
-String windowsResourcesDirPath =
-    path.join(windowsDirPath, 'runner', 'resources');
+String windowsResourcesDirPath = path.join(windowsDirPath, 'runner', 'resources');
 
 /// Relative path to windows icon file path
 String windowsIconFilePath = path.join(windowsResourcesDirPath, 'app_icon.ico');
@@ -77,24 +100,19 @@ const int windowsDefaultIconSize = 48;
 final macOSDirPath = path.join('macos');
 
 /// Relative path to macos icons folder
-final macOSIconsDirPath =
-    path.join(macOSDirPath, 'Runner', 'Assets.xcassets', 'AppIcon.appiconset');
+final macOSIconsDirPath = path.join(macOSDirPath, 'Runner', 'Assets.xcassets', 'AppIcon.appiconset');
 
 /// Relative path to macos contents.json
 final macOSContentsFilePath = path.join(macOSIconsDirPath, 'Contents.json');
 
 const String errorMissingImagePath =
     'Missing "image_path" or "image_path_android" + "image_path_ios" within configuration';
-const String errorMissingPlatform =
-    'No platform specified within config to generate icons for.';
-const String errorMissingRegularAndroid =
-    'Adaptive icon config found but no regular Android config. '
+const String errorMissingPlatform = 'No platform specified within config to generate icons for.';
+const String errorMissingRegularAndroid = 'Adaptive icon config found but no regular Android config. '
     'Below API 26 the regular Android config is required';
-const String errorMissingMinSdk =
-    'Cannot not find minSdk from android/app/build.gradle or android/local.properties'
+const String errorMissingMinSdk = 'Cannot not find minSdk from android/app/build.gradle or android/local.properties'
     ' Specify minSdk in your flutter_launcher_config.yaml with "min_sdk_android"';
-const String errorIncorrectIconName =
-    'The icon name must contain only lowercase a-z, 0-9, or underscore: '
+const String errorIncorrectIconName = 'The icon name must contain only lowercase a-z, 0-9, or underscore: '
     'E.g. "ic_my_new_icon"';
 
 String introMessage(String currentVersion) => '''

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,8 +78,7 @@ Future<void> createIconsFromArguments(List<String> arguments) async {
   if (!hasFlavors) {
     // Load configs from given file(defaults to ./flutter_launcher_icons.yaml) or from ./pubspec.yaml
 
-    final flutterLauncherIconsConfigs =
-        loadConfigFileFromArgResults(argResults);
+    final flutterLauncherIconsConfigs = loadConfigFileFromArgResults(argResults);
     if (flutterLauncherIconsConfigs == null) {
       throw NoConfigFoundException(
         'No configuration found in $defaultConfigFile or in ${constants.pubspecFilePath}. '
@@ -93,17 +92,19 @@ Future<void> createIconsFromArguments(List<String> arguments) async {
         prefixPath,
       );
       print('\n✓ Successfully generated launcher icons');
-    } catch (e) {
+    } catch (e, st) {
       stderr.writeln('\n✕ Could not generate launcher icons');
       stderr.writeln(e);
+      if (logger.isVerbose) {
+        stderr.writeln(st);
+      }
       exit(2);
     }
   } else {
     try {
       for (String flavor in flavors) {
         print('\nFlavor: $flavor');
-        final flutterLauncherIconsConfigs =
-            Config.loadConfigFromFlavor(flavor, prefixPath);
+        final flutterLauncherIconsConfigs = Config.loadConfigFromFlavor(flavor, prefixPath);
         if (flutterLauncherIconsConfigs == null) {
           throw NoConfigFoundException(
             'No configuration found for $flavor flavor.',
@@ -117,9 +118,12 @@ Future<void> createIconsFromArguments(List<String> arguments) async {
         );
       }
       print('\n✓ Successfully generated launcher icons for flavors');
-    } catch (e) {
+    } catch (e, st) {
       stderr.writeln('\n✕ Could not generate launcher icons for flavors');
       stderr.writeln(e);
+      if (logger.isVerbose) {
+        stderr.writeln(st);
+      }
       exit(2);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_launcher_icons
 description: A package which simplifies the task of updating your Flutter app's launcher icon.
-version: 0.13.1
+version: 0.14.0
 maintainer: Mark O'Sullivan (@MarkOSullivan94)
 homepage: https://github.com/fluttercommunity/flutter_launcher_icons
 repository: https://github.com/fluttercommunity/flutter_launcher_icons/


### PR DESCRIPTION
Flutter 3.13 added support for renaming the Xcode directory on iOS, but there have been issues with both Flutter and third-party packages such as this one relying on the iOS project being named `Runner`. (See: https://github.com/flutter/flutter/issues/135201)

This PR adds support for renamed iOS projects by searching the `ios/` directory for the first directory containing the files that `flutter_launcher_icons` is looking for - e.g., the first directory in `ios/` that contains `Assets.xcassets`, instead of just `ios/Runner/Assets.xcassets` (effectively using the glob `ios/*/Assets.xcassets` in this case and using the first result).

- If such a directory is not found, it will fall back to `Runner` (though the `Runner` directory should also be found under this logic) and will then fallback to existing logic.
- This check is also performed once and then passed around to ensure we don't waste time scanning the `ios/` directory every time such a file is needed.