### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ An example is shown below. More complex examples [can be found in the example pr
 dev_dependencies:
   flutter_launcher_icons: "^0.13.1"
 
-flutter_launcher_icons:
+flutter_icons:
   android: "launcher_icon"
   ios: true
   image_path: "assets/icon/icon.png"


### PR DESCRIPTION
Changed "flutter_launcher_icons" to "flutter_icons" to fix broken example.  The dependency should be "flutter_launcher_icons" (as is) but the paths need to be specified under "flutter_icons" (currently the example says "flutter_launcher_icons" which results in this error:

✗ ERROR: NoConfigFoundException
No configuration found in flutter_launcher_icons.yaml or in pubspec.yaml. In case file exists in different directory use --file option
#0      createIconsFromArguments (package:flutter_launcher_icons/main.dart:85:7)


but changing it to "flutter_icons" works: 
Creating Icons for Web...
Creating Icons for Windows...
Creating Icons for MacOS...

✓ Successfully generated launcher icons


-> I actually had to google as the example wasn't working, but StackOverflow to the rescue:
https://stackoverflow.com/questions/69509861/check-that-your-config-file-flutter-launcher-icons-yaml-has-a-flutter-icons