### PR TITLE
Only update app icon related configs

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -173,7 +173,7 @@ Future<void> changeIosLauncherIcon(String iconName, String? flavor) async {
 
       if (currentConfig != null &&
           (flavor == null || currentConfig.contains('-$flavor')) &&
-          line.contains('ASSETCATALOG')) {
+          line.contains('ASSETCATALOG') &&  line.contains('APPICON_NAME')) {
         lines[x] = line.replaceAll(RegExp('\=(.*);'), '= $iconName;');
       }
     }


### PR DESCRIPTION
In our app we have an App Clip. Embedding an app clip requires multiple changes to project file entities that contain the phrase "ASSETCATALOG" as seen below. There was a line of code that set all ASSETCATALOG related project file entries to the app icon name that was causing our project file to be corrupted because it was changing all of the following fields to the icon name:

ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-dev";
ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;

This change ensures that the only fields that get changed to the app icon name are app icon-related fields.