### PR TITLE
related to [issue #96], Suggestion for an easier way to apply foreground inset

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Shown below is the full list of attributes which you can specify within your Flu
 be used to fill out the background of the adaptive icon.
 - `adaptive_icon_foreground`: The image asset which will be used for the icon foreground of the adaptive icon
 *Note: Adaptive Icons will only be generated when both adaptive_icon_background and adaptive_icon_foreground are specified. (the image_path is not automatically taken as foreground)*
+- `adaptive_icon_foreground_inset`: This is used to add padding to the icon when applying an adaptive icon. The default value is `16`.
 - `adaptive_icon_monochrome`: The image asset which will be used for the icon
 foreground of the Android 13+ themed icon. For more information see [Android Adaptive Icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#user-theming)
 

--- a/example/default_example/pubspec.yaml
+++ b/example/default_example/pubspec.yaml
@@ -21,6 +21,7 @@ flutter_launcher_icons:
   ios: true # can specify file name here e.g. "My-Launcher-Icon"
   adaptive_icon_background: "assets/images/christmas-background.png" # only available for Android 8.0 devices and above
   adaptive_icon_foreground: "assets/images/icon-foreground-432x432.png" # only available for Android 8.0 devices and above
+  adaptive_icon_foreground_inset: 16 # only available for Android 8.0 devices and above
   adaptive_icon_monochrome: "assets/images/icon-monochrome-432x432.png" # only available for Android 13 devices and above
   min_sdk_android: 21 # android min sdk min:16, default 21
   remove_alpha_ios: true

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -172,7 +172,7 @@ void createMipmapXmlFile(
     }
 
     xmlContent +=
-        '  <foreground android:drawable="@drawable/ic_launcher_foreground"/>\n';
+        '  <foreground>\n    <inset\n      android:drawable="@drawable/ic_launcher_foreground"\n      android:inset="${config.adaptiveIconForegroundInset}%" />\n  </foreground>';
   }
 
   if (config.hasAndroidAdaptiveMonochromeConfig) {

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -172,7 +172,7 @@ void createMipmapXmlFile(
     }
 
     xmlContent +=
-        '  <foreground>\n    <inset\n      android:drawable="@drawable/ic_launcher_foreground"\n      android:inset="${config.adaptiveIconForegroundInset}%" />\n  </foreground>';
+        '  <foreground>\n    <inset\n      android:drawable="@drawable/ic_launcher_foreground"\n      android:inset="${config.adaptiveIconForegroundInset}%" />\n  </foreground>\n';
   }
 
   if (config.hasAndroidAdaptiveMonochromeConfig) {

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -171,13 +171,23 @@ void createMipmapXmlFile(
           '  <background android:drawable="@color/ic_launcher_background"/>\n';
     }
 
-    xmlContent +=
-        '  <foreground>\n    <inset\n      android:drawable="@drawable/ic_launcher_foreground"\n      android:inset="${config.adaptiveIconForegroundInset}%" />\n  </foreground>\n';
+    xmlContent += '''
+  <foreground>
+      <inset
+          android:drawable="@drawable/ic_launcher_foreground"
+          android:inset="${config.adaptiveIconForegroundInset}%" />
+  </foreground>
+''';
   }
 
   if (config.hasAndroidAdaptiveMonochromeConfig) {
-    xmlContent +=
-        '  <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>\n';
+    xmlContent += '''
+  <monochrome>
+      <inset
+          android:drawable="@drawable/ic_launcher_monochrome"
+          android:inset="${config.adaptiveIconForegroundInset}%" />
+  </monochrome>
+''';
   }
 
   late File mipmapXmlFile;

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -26,6 +26,7 @@ class Config {
     this.imagePathAndroid,
     this.imagePathIOS,
     this.adaptiveIconForeground,
+    this.adaptiveIconForegroundInset = 16,
     this.adaptiveIconBackground,
     this.adaptiveIconMonochrome,
     this.minSdkAndroid = constants.androidDefaultAndroidMinSDK,
@@ -120,6 +121,10 @@ class Config {
   /// android adaptive_icon_foreground image
   @JsonKey(name: 'adaptive_icon_foreground')
   final String? adaptiveIconForeground;
+
+  /// android adaptive_icon_foreground inset
+  @JsonKey(name: 'adaptive_icon_foreground_inset')
+  final int adaptiveIconForegroundInset;
 
   /// android adaptive_icon_background image
   @JsonKey(name: 'adaptive_icon_background')

--- a/lib/config/config.g.dart
+++ b/lib/config/config.g.dart
@@ -19,6 +19,8 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
           imagePathIOS: $checkedConvert('image_path_ios', (v) => v as String?),
           adaptiveIconForeground:
               $checkedConvert('adaptive_icon_foreground', (v) => v as String?),
+          adaptiveIconForegroundInset:
+              $checkedConvert('adaptive_icon_foreground_inset', (v) => v as int? ?? 16),
           adaptiveIconBackground:
               $checkedConvert('adaptive_icon_background', (v) => v as String?),
           adaptiveIconMonochrome:
@@ -43,6 +45,7 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
         'imagePathAndroid': 'image_path_android',
         'imagePathIOS': 'image_path_ios',
         'adaptiveIconForeground': 'adaptive_icon_foreground',
+        'adaptiveIconForegroundInset': 'adaptive_icon_foreground_inset',
         'adaptiveIconBackground': 'adaptive_icon_background',
         'adaptiveIconMonochrome': 'adaptive_icon_monochrome',
         'minSdkAndroid': 'min_sdk_android',
@@ -61,6 +64,7 @@ Map<String, dynamic> _$ConfigToJson(Config instance) => <String, dynamic>{
       'image_path_android': instance.imagePathAndroid,
       'image_path_ios': instance.imagePathIOS,
       'adaptive_icon_foreground': instance.adaptiveIconForeground,
+      'adaptive_icon_foreground_inset': instance.adaptiveIconForegroundInset,
       'adaptive_icon_background': instance.adaptiveIconBackground,
       'adaptive_icon_monochrome': instance.adaptiveIconMonochrome,
       'min_sdk_android': instance.minSdkAndroid,


### PR DESCRIPTION
I requested a PR for those who find it bothersome to change it manually every time. The default value for the inset is 16.

how to use:
~~~yaml
flutter_launcher_icons:
  android: true
  ios: true
  remove_alpha_ios: true
  image_path: "assets/app_icon/icon.png"
  adaptive_icon_background: "assets/app_icon/adaptive_icon_background.png"
  adaptive_icon_foreground: "assets/app_icon/adaptive_icon_foreground.png"
  adaptive_icon_foreground_inset: 16  # default value is 16
~~~


before:
~~~xml
<?xml version="1.0" encoding="utf-8"?>
<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
  <background android:drawable="@drawable/ic_launcher_background"/>
  <foreground android:drawable="@drawable/ic_launcher_foreground"/>
</adaptive-icon>
~~~

after:
~~~xml
<?xml version="1.0" encoding="utf-8"?>
<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
  <background android:drawable="@drawable/ic_launcher_background"/>
  <foreground>
    <inset
      android:drawable="@drawable/ic_launcher_foreground"
      android:inset="16%" />
  </foreground>
</adaptive-icon>
~~~

