### PR TITLE
Adaptive Icon Scaling for Android

### DIFF
--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -28,6 +28,8 @@ class Config {
     this.adaptiveIconForeground,
     this.adaptiveIconBackground,
     this.adaptiveIconMonochrome,
+    this.adaptiveIconForegroundScaleFactor,
+    this.adaptiveIconForegroundScaleFillColor,
     this.minSdkAndroid = constants.androidDefaultAndroidMinSDK,
     this.removeAlphaIOS = false,
     this.backgroundColorIOS = '#ffffff',
@@ -125,6 +127,14 @@ class Config {
   @JsonKey(name: 'adaptive_icon_background')
   final String? adaptiveIconBackground;
 
+  /// android adaptive_icon_foreground_scale_factor
+  @JsonKey(name: 'adaptive_icon_foreground_scale_factor')
+  final double? adaptiveIconForegroundScaleFactor;
+
+  /// android adaptive_icon_foreground_scale_fill_color
+  @JsonKey(name: 'adaptive_icon_foreground_scale_fill_color')
+  final String? adaptiveIconForegroundScaleFillColor;
+
   /// android adaptive_icon_background image
   @JsonKey(name: 'adaptive_icon_monochrome')
   final String? adaptiveIconMonochrome;
@@ -195,6 +205,11 @@ class Config {
 
   /// if we are needing a new iOS icon
   bool get isNeedingNewIOSIcon => ios != false;
+
+  /// wether to rescale the foreground android icon
+  bool get rescaleAndroidIcon =>
+      adaptiveIconForegroundScaleFactor != null &&
+      adaptiveIconForegroundScaleFactor! > 0;
 
   /// Method for the retrieval of the Android icon path
   /// If image_path_android is found, this will be prioritised over the image_path

--- a/lib/config/config.g.dart
+++ b/lib/config/config.g.dart
@@ -19,6 +19,10 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
           imagePathIOS: $checkedConvert('image_path_ios', (v) => v as String?),
           adaptiveIconForeground:
               $checkedConvert('adaptive_icon_foreground', (v) => v as String?),
+          adaptiveIconForegroundScaleFactor: $checkedConvert(
+              'adaptive_icon_foreground_scale_factor', (v) => v as double?),
+          adaptiveIconForegroundScaleFillColor: $checkedConvert(
+              'adaptive_icon_foreground_scale_fill_color', (v) => v as String?),
           adaptiveIconBackground:
               $checkedConvert('adaptive_icon_background', (v) => v as String?),
           adaptiveIconMonochrome:
@@ -43,6 +47,10 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
         'imagePathAndroid': 'image_path_android',
         'imagePathIOS': 'image_path_ios',
         'adaptiveIconForeground': 'adaptive_icon_foreground',
+        'adaptiveIconForegroundScaleFactor':
+            'adaptive_icon_foreground_scale_factor',
+        'adaptiveIconForegroundScaleFillColor':
+            'adaptive_icon_foreground_scale_fill_color',
         'adaptiveIconBackground': 'adaptive_icon_background',
         'adaptiveIconMonochrome': 'adaptive_icon_monochrome',
         'minSdkAndroid': 'min_sdk_android',
@@ -61,6 +69,10 @@ Map<String, dynamic> _$ConfigToJson(Config instance) => <String, dynamic>{
       'image_path_android': instance.imagePathAndroid,
       'image_path_ios': instance.imagePathIOS,
       'adaptive_icon_foreground': instance.adaptiveIconForeground,
+      'adaptive_icon_foreground_scale_factor':
+          instance.adaptiveIconForegroundScaleFactor,
+      'adaptive_icon_foreground_scale_fill_color':
+          instance.adaptiveIconForegroundScaleFillColor,
       'adaptive_icon_background': instance.adaptiveIconBackground,
       'adaptive_icon_monochrome': instance.adaptiveIconMonochrome,
       'min_sdk_android': instance.minSdkAndroid,


### PR DESCRIPTION
This is a rebased version of pull request #181, updated to work with the dependencies currently used in `flutter_launcher_icons:master`.


Since the adaptive icons seems to have extra padding when compared to their iOS counter parts I added a new scaling factor parameter so that the image for the adaptive icon can be scaled before finally scaling down to icon size. This scaling is done by enlarging the canvas, not scaling down the original image, so image quality should in theory be better. The two new yaml parameters are:

```
adaptive_icon_foreground_scale_factor: 0.66
adaptive_icon_foreground_scale_fill_color: "#FFFFFFFF" #probably not needed as default is fill transparent
```

Adding background image scaling will be next.