### PR TITLE
Android, stretched icons bug fixed

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -19,11 +19,11 @@ class AndroidIconTemplate {
 }
 
 final List<AndroidIconTemplate> adaptiveForegroundIcons = <AndroidIconTemplate>[
-  AndroidIconTemplate(directoryName: 'drawable-mdpi', size: 108),
-  AndroidIconTemplate(directoryName: 'drawable-hdpi', size: 162),
-  AndroidIconTemplate(directoryName: 'drawable-xhdpi', size: 216),
-  AndroidIconTemplate(directoryName: 'drawable-xxhdpi', size: 324),
-  AndroidIconTemplate(directoryName: 'drawable-xxxhdpi', size: 432),
+  AndroidIconTemplate(directoryName: 'drawable-mdpi', size: 48),
+  AndroidIconTemplate(directoryName: 'drawable-hdpi', size: 72),
+  AndroidIconTemplate(directoryName: 'drawable-xhdpi', size: 96),
+  AndroidIconTemplate(directoryName: 'drawable-xxhdpi', size: 144),
+  AndroidIconTemplate(directoryName: 'drawable-xxxhdpi', size: 192),
 ];
 
 List<AndroidIconTemplate> androidIcons = <AndroidIconTemplate>[

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -171,8 +171,15 @@ void createMipmapXmlFile(
           '  <background android:drawable="@color/ic_launcher_background"/>\n';
     }
 
-    xmlContent +=
-        '  <foreground android:drawable="@drawable/ic_launcher_foreground"/>\n';
+    xmlContent += '  <foreground>\n'
+        '    <inset\n'
+        '        android:insetBottom="10dp"\n'
+        '        android:insetLeft="10dp"\n'
+        '        android:insetRight="10dp"\n'
+        '        android:insetTop="10dp">\n'
+        '      <bitmap android:src="@drawable/ic_launcher_foreground" />\n'
+        '    </inset>\n'
+        '  </foreground>\n';
   }
 
   if (config.hasAndroidAdaptiveMonochromeConfig) {


### PR DESCRIPTION
To fix the exaggerated stretching problem I had to make a small adjustment to ic_launcher.xml and add an <inset> tag which allows controlling the area within which the foreground content is rendered, preventing it from being deformed or seen outside of proportion on different devices or resolutions.

By the way, I didn't understand the need for drawable to be 2.25 times larger than mipmap, by default it should be:

mdpi: 48x48 pixels
hdpi: 72x72 pixels
xhdpi: 96x96 pixels
xxhdpi: 144x144 pixels
xxxhdpi: 192x192 pixels

I had to modify the drawables because some icons seemed slightly stretched.

my "pubspec.yaml":
flutter_launcher_icons:
  android: true # or (android: "custom name for icons and the ic_launcher.xml") I prefer the default name to avoid confusion
  ios: true
  image_path: "assets/icon/icon.png" # 512x512 recommended
  adaptive_icon_background: "#2B2B2B" # optional background color
  adaptive_icon_foreground: "assets/icon/icon_foreground.png"  # Your circular icon, 512x512 recommended
  
  ![asdasd](https://github.com/user-attachments/assets/a9cd29e8-1e4c-4595-af93-1426c71a9867)