### PR TITLE
Corrected run commands in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A command-line tool which simplifies the task of updating your Flutter app's lau
 Run the following command to create a new config automatically:
 
 ```shell
-dart run run flutter_launcher_icons:generate
+dart run flutter_launcher_icons:generate
 ```
 
 This will create a new file called `flutter_launcher_icons.yaml` in your `flutter` project's root directory.
@@ -21,13 +21,13 @@ This will create a new file called `flutter_launcher_icons.yaml` in your `flutte
 If you want to override the default location or name of the config file, use the `-f` flag:
 
 ```shell
-dart run run flutter_launcher_icons:generate -f <your config file name here>
+dart run flutter_launcher_icons:generate -f <your config file name here>
 ```
 
 To override an existing config file, use the `-o` flag:
 
 ```shell
-dart run run flutter_launcher_icons:generate -o
+dart run flutter_launcher_icons:generate -o
 ```
 
 OR
@@ -64,7 +64,7 @@ After setting up the configuration, all that is left to do is run the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons
+dart run flutter_launcher_icons
 ```
 
 If you name your configuration file something other than `flutter_launcher_icons.yaml` or `pubspec.yaml` you will need to specify
@@ -72,7 +72,7 @@ the name of the file when running the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons -f <your config file name here>
+dart run flutter_launcher_icons -f <your config file name here>
 ```
 
 Note: If you are not using the existing `pubspec.yaml` ensure that your config file is located in the same directory as it.


### PR DESCRIPTION
This PR updates and fixes the commands used to generate and manage configuration files for the flutter_launcher_icons package.

closes #580