### PR TITLE
docs: replaced deprecated `flutter pub run` with `dart run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After setting up the configuration, all that is left to do is run the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons
+dart run flutter_launcher_icons
 ```
 
 If you name your configuration file something other than `flutter_launcher_icons.yaml` or `pubspec.yaml` you will need to specify
@@ -72,7 +72,7 @@ the name of the file when running the package.
 
 ```shell
 flutter pub get
-flutter pub run flutter_launcher_icons -f <your config file name here>
+dart run flutter_launcher_icons -f <your config file name here>
 ```
 
 Note: If you are not using the existing `pubspec.yaml` ensure that your config file is located in the same directory as it.


### PR DESCRIPTION
Changes:
- **Readme.md** - mentioned `flutter pub run`, which as of now has been deprecated. Replaced these lines with `dart run`.