### PR TITLE
fix(template): wrong attribute to remove alpha channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Shown below is the full list of attributes which you can specify within your Flu
   - `true`: Override the default existing Flutter launcher icon for the platform specified
   - `false`: Ignore making launcher icons for this platform
   - `icon/path/here.png`: This will generate a new launcher icons for the platform with the name you specify, without removing the old default existing Flutter launcher icon.
-- `image_path`: The location of the icon image file which you want to use as the app launcher icon
 - `image_path_android`: The location of the icon image file specific for Android platform (optional - if not defined then the image_path is used)
 - `min_sdk_android`: Specify android min sdk value
 **The next two attributes are only used when generating Android launcher icon**

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -91,6 +91,7 @@ flutter_launcher_icons:
   min_sdk_android: 21 # android min sdk min:16, default 21
   # adaptive_icon_background: "assets/icon/background.png"
   # adaptive_icon_foreground: "assets/icon/foreground.png"
+  # adaptive_icon_foreground_inset: 16
   # adaptive_icon_monochrome: "assets/icon/monochrome.png"
 
   ios: true
@@ -99,6 +100,7 @@ flutter_launcher_icons:
   # image_path_ios_dark_transparent: "assets/icon/icon_dark.png"
   # image_path_ios_tinted_grayscale: "assets/icon/icon_tinted.png"
   # desaturate_tinted_to_grayscale_ios: true
+  # background_color_ios: "#ffffff"
 
   web:
     generate: true

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -95,7 +95,7 @@ flutter_launcher_icons:
 
   ios: true
   # image_path_ios: "assets/icon/icon.png"
-  remove_alpha_channel_ios: true
+  remove_alpha_ios: true
   # image_path_ios_dark_transparent: "assets/icon/icon_dark.png"
   # image_path_ios_tinted_grayscale: "assets/icon/icon_tinted.png"
   # desaturate_tinted_to_grayscale_ios: true


### PR DESCRIPTION
This PR fixes the template after running the command to create a new config automatically:

- [x] Replaced the `remove_alpha_channel_ios` attribute with `remove_alpha_ios`
- [x] Added missing attributes `adaptive_icon_foreground_inset` and `background_color_ios`
- [x] Removed duplicated lines on the readme file