### PR TITLE
chores: remove deprecated rules from analysis_options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
 
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes
@@ -70,7 +69,6 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach


### PR DESCRIPTION
Fixes #590.

The rule `always_require_non_null_named_parameters` is removed in Dart 3.3.0 as we can now use the `required` keyword for mandatory named parameters. For `prefer_equal_for_default_values`, its functionality has been integrated into the core language:
The = syntax is now the only valid way to specify default values for named parameters[1](https://dart.dev/tools/linter-rules/prefer_equal_for_default_values)-[2](https://github.com/dart-lang/language/issues/2357#issuecomment-1339555232)