### PR TITLE
Fixed analysis_options.yaml file

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,7 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
 
-    # - always_require_non_null_named_parameters        (Removed in Dart 3.0.0)
+    # - always_require_non_null_named_parameters        (Removed in Dart 3.3.0)
     - annotate_overrides
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,7 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
 
-    - always_require_non_null_named_parameters
+    # - always_require_non_null_named_parameters        (Removed in Dart 3.0.0)
     - annotate_overrides
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes
@@ -70,7 +70,7 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
+    # - prefer_equal_for_default_values       (Removed in Dart 3.0.0)
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach


### PR DESCRIPTION
# Issue: Removal of Lint Rules in `analysis_options.yaml` #590

## Description

In recent updates of Dart, several lint rules specified in the `analysis_options.yaml` file have been removed. This change impacts code quality checks and may lead to unintended code issues going unnoticed in projects that previously relied on these rules.

### Steps to Reproduce

1. Open an existing Dart project with a `analysis_options.yaml` file containing the following rules:
    ```yaml
    linter:
      rules:
        - always_require_non_null_named_parameters
        - prefer_equal_for_default_values
    ```
2. Upgrade Dart to the latest version.
3. Run the analysis tool and observe that the specified rules are no longer applied.

### Expected Behavior

The lint rules specified in `analysis_options.yaml` should remain active and continue to enforce code quality standards across the project.

### Actual Behavior

The specified lint rules are either ignored or result in warnings indicating that they are no longer available.

### Impact

- Decreased code quality due to the lack of enforcement of important linting rules.
- Increased technical debt as developers may not be aware of the missing rules.
- Disruption to CI/CD processes that depend on these lint checks.

### Suggested Solution

Consider reintroducing the removed rules or provide alternatives that serve the same purpose. Updating the official documentation to clarify the changes and recommend equivalent rules would also help developers adapt to the new standards.

### Additional Information

- Dart Version: 3.3.0 and 3.0.0 respectively
- Example of affected `analysis_options.yaml`:
    ```yaml
    linter:
      rules:
        - always_require_non_null_named_parameters
        - prefer_equal_for_default_values
    ```
- Environment: [e.g., Flutter, Dart VM, etc.]
