### PR TITLE
fix(Android): show blank icon if no adaptive icon set

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -3,8 +3,8 @@
 import 'dart:io';
 
 import 'package:flutter_launcher_icons/config/config.dart';
-import 'package:flutter_launcher_icons/constants.dart';
 import 'package:flutter_launcher_icons/constants.dart' as constants;
+import 'package:flutter_launcher_icons/constants.dart';
 import 'package:flutter_launcher_icons/custom_exceptions.dart';
 import 'package:flutter_launcher_icons/utils.dart' as utils;
 import 'package:flutter_launcher_icons/xml_templates.dart' as xml_template;
@@ -158,6 +158,15 @@ void createMipmapXmlFile(
   Config config,
   String? flavor,
 ) {
+  // Note: Adaptive Icons will only be used when both
+  // `adaptive_icon_background` and `adaptive_icon_foreground` or
+  // `adaptive_icon_monochrome` are specified (The `image_path` is not
+  // automatically taken as foreground)
+  if (!config.hasAndroidAdaptiveConfig &&
+      !config.hasAndroidAdaptiveMonochromeConfig) {
+    return;
+  }
+
   utils.printStatus('Creating mipmap xml file Android');
 
   String xmlContent = '';


### PR DESCRIPTION
Fixes #578, #579, #585, #589, #594, #595, #600

In the new version 0.14.1, not everyone specified `adaptive_icon_background` and `adaptive_icon_foreground` or `adaptive_icon_monochrome` in their Android configuration, so the app icon may be black/blank after generating.

As suggested by https://github.com/fluttercommunity/flutter_launcher_icons/issues/579#issuecomment-2370664455, you can delete the `android/app/src/main/res/mipmap-anydpi-v26/${androidIconName}.xml` file after running generating to solve this issue.

However, it will still always create this file. I think this file should only be created if any configuration related to adaptive icons is set up.