### PR TITLE
fix : rename remove_alpha_ios for generate

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -95,7 +95,7 @@ flutter_launcher_icons:
 
   ios: true
   # image_path_ios: "assets/icon/icon.png"
-  remove_alpha_channel_ios: true
+  remove_alpha_ios: true
   # image_path_ios_dark_transparent: "assets/icon/icon_dark.png"
   # image_path_ios_tinted_grayscale: "assets/icon/icon_tinted.png"
   # desaturate_tinted_to_grayscale_ios: true


### PR DESCRIPTION
When using the generate command, the yaml file generates `remove_alpha_channel_ios: true` configuration, which is not valid in the latest version. It has been renamed to `remove_alpha_ios`.

This creates an issue for iOS icon transparency compliance since the older `emove_alpha_channel_ios` key does not work