### PR TITLE
docs: replace broken Android adaptive icon reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ be used to fill out the background of the adaptive icon.
 *Note: Adaptive Icons will only be generated when both adaptive_icon_background and adaptive_icon_foreground are specified. (the image_path is not automatically taken as foreground)*
 - `adaptive_icon_foreground_inset`: This is used to add padding (in %) to the foreground icon when generating an adaptive icon. The default value is `16`.
 - `adaptive_icon_monochrome`: The image asset which will be used for the icon
-foreground of the Android 13+ themed icon. For more information see [Android Adaptive Icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#user-theming)
+foreground of the Android 13+ themed icon. For more information see [Android Adaptive Icons](https://developer.android.com/about/versions/13/features#themed-app-icons)
 
 ### IOS
 


### PR DESCRIPTION
## Summary
- replaces a broken Android docs link for `adaptive_icon_monochrome` in README
- updates it to the Android 13 themed app icons section that currently resolves

## Why
- issue report: the existing `icon_design_adaptive#user-theming` URL is broken

## Validation
- verified old URL returns HTTP 404
- verified replacement URL returns HTTP 200

## Checks run
- no code changes; docs-only README link update

## Residual uncertainty
- Android docs can be reorganized in the future, but this target is currently live and relevant.

Ref: https://github.com/fluttercommunity/flutter_launcher_icons/issues/667
