### PR TITLE
Improve logs and skip validation for disabled platforms

### DIFF
--- a/lib/abs/icon_generator.dart
+++ b/lib/abs/icon_generator.dart
@@ -28,6 +28,9 @@ abstract class IconGenerator {
   /// Creates icons for this platform.
   Future<void> createIcons();
 
+  /// Whether icon generation is enabled in the platform configuration.
+  bool get isEnabled;
+
   /// Should return `true` if this platform
   /// has all the requirements to create icons.
   /// This runs before to [createIcons]
@@ -89,6 +92,10 @@ Future<void> generateIconsFor({
     }
 
     for (final platform in platformList) {
+      if (!platform.isEnabled) {
+        logger.info('${platform.platformName} skipped in the config');
+        continue;
+      }
       final progress =
           logger.progress('Creating Icons for ${platform.platformName}');
       logger.verbose(

--- a/lib/macos/macos_icon_generator.dart
+++ b/lib/macos/macos_icon_generator.dart
@@ -28,6 +28,9 @@ class MacOSIconGenerator extends IconGenerator {
   MacOSIconGenerator(IconGeneratorContext context) : super(context, 'MacOS');
 
   @override
+  bool get isEnabled => context.macOSConfig?.generate ?? false;
+
+  @override
   Future<void> createIcons() async {
     final imgFilePath = path.join(
       context.prefixPath,

--- a/lib/web/web_icon_generator.dart
+++ b/lib/web/web_icon_generator.dart
@@ -47,6 +47,9 @@ class WebIconGenerator extends IconGenerator {
   WebIconGenerator(IconGeneratorContext context) : super(context, 'Web');
 
   @override
+  bool get isEnabled => context.webConfig?.generate ?? false;
+
+  @override
   Future<void> createIcons() async {
     final imgFilePath = path.join(
       context.prefixPath,

--- a/lib/windows/windows_icon_generator.dart
+++ b/lib/windows/windows_icon_generator.dart
@@ -12,6 +12,9 @@ class WindowsIconGenerator extends IconGenerator {
       : super(context, 'Windows');
 
   @override
+  bool get isEnabled => context.windowsConfig?.generate ?? false;
+
+  @override
   Future<void> createIcons() async {
     final imgFilePath = path.join(
       context.prefixPath,

--- a/test/abs/icon_generator_test.dart
+++ b/test/abs/icon_generator_test.dart
@@ -22,6 +22,7 @@ void main() {
       logger = FLILogger(false);
       mockGenerator = MockIconGenerator();
       when(mockGenerator.platformName).thenReturn('Mock');
+      when(mockGenerator.isEnabled).thenReturn(true);
       when(mockGenerator.context).thenReturn(
         IconGeneratorContext(
           config: mockFLIConfig,
@@ -56,6 +57,19 @@ void main() {
         platforms: (context) => [mockGenerator],
       );
       verify(mockGenerator.validateRequirements()).called(equals(1));
+      verifyNever(mockGenerator.createIcons());
+    });
+
+    test('should skip disabled platform without validating requirements', () {
+      when(mockGenerator.isEnabled).thenReturn(false);
+      generateIconsFor(
+        config: mockFLIConfig,
+        flavor: null,
+        prefixPath: prefixPath,
+        logger: logger,
+        platforms: (context) => [mockGenerator],
+      );
+      verifyNever(mockGenerator.validateRequirements());
       verifyNever(mockGenerator.createIcons());
     });
 

--- a/test/abs/icon_generator_test.mocks.dart
+++ b/test/abs/icon_generator_test.mocks.dart
@@ -166,6 +166,12 @@ class MockIconGenerator extends _i1.Mock implements _i2.IconGenerator {
       ) as String);
 
   @override
+  bool get isEnabled => (super.noSuchMethod(
+        Invocation.getter(#isEnabled),
+        returnValue: false,
+      ) as bool);
+
+  @override
   _i5.Future<void> createIcons() => (super.noSuchMethod(
         Invocation.method(
           #createIcons,


### PR DESCRIPTION
During CI runs for app builds I noticed that if icons generation for some platform is disabled in the yaml file, like with 
```
  web:
    generate: false
```
logs output shows `Requirements failed for platform....` line which is misleading and confuses users. Here is an example with `before`:

<img width="563" height="349" alt="Screenshot 2026-07-15 at 00 25 25" src="https://github.com/user-attachments/assets/70f432c5-9e1e-42de-9615-a06b394bc8a1" />

This PR changes logs output, so if some platform has `generate: false` there will be no lines about requirements failed as well as no config validation calls.

Here is `after`:
<img width="440" height="274" alt="Screenshot 2026-07-15 at 00 49 41" src="https://github.com/user-attachments/assets/f9eec52e-8290-4da5-8236-f5f6c9aa78bc" />

P.S. Didn't touch logger functions in Android and iOS, because while it would be good to unify all platforms, the PR would have a much bigger scope than initially planned.



